### PR TITLE
feat: allow to set auth id with api

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -10,6 +10,7 @@
 		{ "hook": "filter:admin.header.build", "method": "addAdminNavigation" },
 		{ "hook": "static:user.delete", "method": "deleteUserData" },
 		{ "hook": "filter:user.whitelistFields", "method": "whitelistFields" },
+		{ "hook": "filter:user.updateProfile", "method": "updateProfile" },
 		{ "hook": "filter:auth.init", "method": "loadStrategies" }
 	],
 	"modules": {


### PR DESCRIPTION
Hi Julian!

We want to create users with API in before they log in, so their profile is set up correctly and we have a full control.

I wasn't able to change my `authId` via API, so I needed to tweak the plugin.

I checked the code I know that users can log in with email, but it might be unverified. And we want to set users profile and avatar before the user logs in. And finally, this is how we do it with the session sharing plugin, so it would be great to it in the same way.

If there is a way how to do this using API without this code, please let me know (but we are using v3.7).

Thank you for all the awesome work you do on NodeBB,
Tomas