### PR TITLE
fix(admin): use benchpress render for OAuth strategy modal

### DIFF
--- a/static/lib/admin.js
+++ b/static/lib/admin.js
@@ -17,7 +17,7 @@ export function init() {
 			switch (action) {
 				case 'new': {
 					const title = 'New OAuth2 Strategy';
-					const message = await app.parseAndTranslate('partials/edit-oauth2-strategy', {});
+					const message = await render('partials/edit-oauth2-strategy', {});
 					confirm({
 						title,
 						message,
@@ -33,7 +33,7 @@ export function init() {
 					const name = subselector.closest('[data-name]').getAttribute('data-name');
 					const { strategy } = await get(`/plugins/oauth2-multiple/strategies/${name}`);
 					const title = 'Edit OAuth2 Strategy';
-					const message = await app.parseAndTranslate('partials/edit-oauth2-strategy', { ...strategy });
+					const message = await render('partials/edit-oauth2-strategy', { ...strategy });
 					confirm({
 						title,
 						message,


### PR DESCRIPTION
## Summary
- On NodeBB 4, `app.parseAndTranslate()` returns a jQuery object, while `bootbox` / `modals.confirm` expect an HTML string for `message`.
- Creating or editing an OAuth2 strategy in ACP therefore fails with: `"message" option must not be null or an empty string.`
- Switch the New/Edit strategy modal to `render()` from benchpress (already used elsewhere in this file), which returns a string.

## Test plan
- [ ] Install/activate this branch on NodeBB ≥ 4.14
- [ ] ACP → Plugins → Multiple OAuth2 → **New Endpoint** opens the strategy modal (no console error)
- [ ] Fill and save a strategy, then **Edit** it — modal opens with existing values
- [ ] OAuth login flow still works (runtime unchanged; ACP-only fix)