### PR TITLE
fix: provider claim mapping (Microsoft, GitHub) and inert usernameViaEmail option

### DIFF
--- a/library.js
+++ b/library.js
@@ -166,13 +166,18 @@ OAuth.parseUserReturn = async (provider, profile) => {
 		id, sub,
 		name, nickname, preferred_username,
 		given_name, middle_name, family_name,
+		givenname, familyname,
 		picture, roles, email, email_verified,
 	} = profile;
 	const { usernameViaEmail, forceUsernameViaEmail, idKey } = await OAuth.getStrategy(provider);
 
 	const displayName = nickname || preferred_username || name;
 
-	const combinedFullName = [given_name, middle_name, family_name].filter(Boolean).join(' ');
+	const combinedFullName = [
+		given_name || givenname,
+		middle_name,
+		family_name || familyname,
+	].filter(Boolean).join(' ');
 	const fullname = name || combinedFullName;
 
 	const normalized = {

--- a/library.js
+++ b/library.js
@@ -164,14 +164,14 @@ OAuth.getUserProfile = function (name, userRoute, accessToken, done) {
 OAuth.parseUserReturn = async (provider, profile) => {
 	const {
 		id, sub,
-		name, nickname, preferred_username,
+		name, nickname, preferred_username, login,
 		given_name, middle_name, family_name,
 		givenname, familyname,
-		picture, roles, email, email_verified,
+		picture, avatar_url, roles, email, email_verified,
 	} = profile;
 	const { usernameViaEmail, forceUsernameViaEmail, idKey } = await OAuth.getStrategy(provider);
 
-	const displayName = nickname || preferred_username || name;
+	const displayName = nickname || preferred_username || login || name;
 
 	const combinedFullName = [
 		given_name || givenname,
@@ -185,7 +185,7 @@ OAuth.parseUserReturn = async (provider, profile) => {
 		id: profile[idKey] || id || sub,
 		displayName,
 		fullname,
-		picture,
+		picture: picture || avatar_url,
 		roles,
 		email,
 		email_verified,

--- a/library.js
+++ b/library.js
@@ -191,7 +191,8 @@ OAuth.parseUserReturn = async (provider, profile) => {
 		email_verified,
 	};
 
-	if (forceUsernameViaEmail || (!normalized.displayName && email && usernameViaEmail === 'on')) {
+	if (parseInt(forceUsernameViaEmail, 10) ||
+		(!normalized.displayName && email && parseInt(usernameViaEmail, 10))) {
 		normalized.displayName = email.split('@')[0];
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@
   dependencies:
     "@commitlint/config-angular-type-enum" "^21.0.1"
 
-"@eslint-community/eslint-utils@^4.8.0":
+"@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.9.1"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz"
   integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
@@ -48,6 +48,11 @@
   integrity sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==
   dependencies:
     "@types/json-schema" "^7.0.15"
+
+"@eslint/js@^10.0.0":
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz"
+  integrity sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==
 
 "@eslint/object-schema@^3.0.5":
   version "3.0.5"
@@ -90,6 +95,18 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@stylistic/eslint-plugin@^5.x":
+  version "5.2.2"
+  resolved "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.2.2.tgz"
+  integrity sha512-bE2DUjruqXlHYP3Q2Gpqiuj2bHq7/88FnuaS0FjeGGLCy+X6a07bGVuwtiOYnPSLHR6jmx5Bwdv+j7l8H+G97A==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.7.0"
+    "@typescript-eslint/types" "^8.37.0"
+    eslint-visitor-keys "^4.2.1"
+    espree "^10.4.0"
+    estraverse "^5.3.0"
+    picomatch "^4.0.3"
+
 "@types/esrecurse@^4.3.1":
   version "4.3.1"
   resolved "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz"
@@ -105,12 +122,17 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@typescript-eslint/types@^8.37.0":
+  version "8.38.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.38.0.tgz"
+  integrity sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.16.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0, acorn@^8.16.0:
   version "8.17.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz"
   integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
@@ -195,12 +217,17 @@ eslint-visitor-keys@^3.4.3:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
+eslint-visitor-keys@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
+  integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
+
 eslint-visitor-keys@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
-eslint@10.8.1:
+eslint@^10.0.0, "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@>=9.0.0, eslint@10.8.1:
   version "10.8.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz"
   integrity sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==
@@ -236,6 +263,15 @@ eslint@10.8.1:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+espree@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz"
+  integrity sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^4.2.1"
+
 espree@^11.2.0:
   version "11.2.0"
   resolved "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz"
@@ -259,7 +295,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -459,6 +495,14 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+passport-oauth@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz"
+  integrity sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==
+  dependencies:
+    passport-oauth1 "1.x.x"
+    passport-oauth2 "1.x.x"
+
 passport-oauth1@1.x.x:
   version "1.3.0"
   resolved "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.3.0.tgz"
@@ -479,14 +523,6 @@ passport-oauth2@1.x.x:
     uid2 "0.0.x"
     utils-merge "1.x.x"
 
-passport-oauth@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz"
-  integrity sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==
-  dependencies:
-    passport-oauth1 "1.x.x"
-    passport-oauth2 "1.x.x"
-
 passport-strategy@1.x.x:
   version "1.0.0"
   resolved "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
@@ -502,7 +538,7 @@ path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-picomatch@^4.0.5:
+picomatch@^4.0.3, picomatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==


### PR DESCRIPTION
Three independent bugs found while wiring Microsoft (Entra ID / personal MSA) and GitHub up to this plugin. They are unrelated to each other, so they are separate commits.

### 1. Microsoft's `givenname` / `familyname` claims are ignored

`https://graph.microsoft.com/oidc/userinfo` returns the given/family name **without** underscores, and omits `name`, `nickname` and `preferred_username` entirely. A real response:

```json
{
  "sub": "AAAAAAAAAAAAAAAAAAAAAPxIiNbOEB2t7uk7_u06hig",
  "givenname": "Enes",
  "familyname": "Uysal",
  "email": "…@hotmail.com",
  "locale": "tr-TR",
  "picture": "https://graph.microsoft.com/v1.0/me/photo/$value"
}
```

`parseUserReturn` only destructures `given_name` / `family_name`, so `combinedFullName` is empty and every Microsoft user ends up with a blank `fullname` even with "Sync fullname" enabled.

Because `displayName` is `nickname || preferred_username || name`, it is also `undefined` for these accounts — which makes `loadStrategies` reject the login with `insufficient-scope`, a fairly misleading message given that the scopes are fine and the email is present. The fallback that exists for exactly this case is the `usernameViaEmail` option, which brings us to the second bug.

### 2. `usernameViaEmail` never takes effect

`Controllers.editStrategy` normalises every checkbox before persisting it:

```js
const checkboxes = ['forceUsernameViaEmail', 'usernameViaEmail', 'trustEmailVerified', 'syncFullname', 'syncPicture'];
checkboxes.forEach((prop) => {
	payload[prop] = payload.hasOwnProperty(prop) && payload[prop] === 'on' ? 1 : 0;
});
```

So the stored value is always `1` or `0`, and the ACP template checks `./usernameViaEmail == "1"` accordingly — but `parseUserReturn` compares against the raw form value:

```js
usernameViaEmail === 'on'
```

which cannot match anything `editStrategy` writes. The option is inert for anyone configuring it through the ACP. Every sibling setting is read with `parseInt(…, 10)`; this one now matches. `forceUsernameViaEmail` is given the same treatment for consistency — it currently works only because `0` happens to be falsy as a number.

### 3. GitHub's `login` and `avatar_url` claims are unmapped

`https://api.github.com/user` names those two fields differently from the OIDC conventions the plugin expects:

```json
{ "login": "heudev", "id": 74737994, "name": "Enes Uysal", "avatar_url": "https://avatars.githubusercontent.com/u/74737994" }
```

`login` is the account's actual username, but with no `nickname` or `preferred_username` present `displayName` fell through to `name` — creating forum accounts literally called `Enes Uysal`, spaces and all, instead of `heudev`. And because the avatar is under `avatar_url` rather than `picture`, "Sync picture" had nothing to read and no avatar was ever stored.

`login` is inserted ahead of `name` in the `displayName` chain and `avatar_url` is used as a fallback for `picture`. Note this changes the username assigned to *newly registered* GitHub users; existing accounts keep the username they were created with.

### Testing

Verified against a live NodeBB 4.14.10 forum with both a Microsoft strategy (`userRoute` = `https://graph.microsoft.com/oidc/userinfo`) and a GitHub one (`https://api.github.com/user`). Before: Microsoft logins failed with `insufficient-scope`; GitHub logins produced a space-separated username and no avatar. After: accounts are created with sensible usernames, `fullname` is populated from the provider's claims, and the GitHub avatar syncs. `npx eslint .` is clean.
