### PR TITLE
feat: add option to skip email verification for SSO registrations

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -74,7 +74,7 @@ Controllers.editStrategy = async (req, res) => {
 
 	payload.enabled = !!req.body.enabled;
 
-	const checkboxes = ['forceUsernameViaEmail', 'usernameViaEmail', 'trustEmailVerified', 'syncFullname', 'syncPicture'];
+	const checkboxes = ['forceUsernameViaEmail', 'usernameViaEmail', 'trustEmailVerified', 'skipEmailVerification', 'syncFullname', 'syncPicture'];
 	checkboxes.forEach((prop) => {
 		payload[prop] = payload.hasOwnProperty(prop) && payload[prop] === 'on' ? 1 : 0;
 	});

--- a/library.js
+++ b/library.js
@@ -211,18 +211,45 @@ OAuth.getAssociations = async () => {
 	}));
 };
 
+OAuth.isEmailTrusted = (strategy, payload) => {
+	if (parseInt(strategy.skipEmailVerification, 10)) {
+		return true;
+	}
+
+	return !!parseInt(strategy.trustEmailVerified, 10) &&
+		(payload.email_verified || payload.email_verified === true);
+};
+
+OAuth.confirmEmailIfTrusted = async (payload, uid) => {
+	const strategy = await OAuth.getStrategy(payload.name);
+	if (!payload.email || !OAuth.isEmailTrusted(strategy, payload)) {
+		return;
+	}
+
+	const { email, 'email:confirmed': confirmed } = await user.getUserFields(uid, ['email', 'email:confirmed']);
+	if (parseInt(confirmed, 10) === 1 || (email && email.toLowerCase() !== payload.email.toLowerCase())) {
+		return;
+	}
+
+	if (!email) {
+		await user.setUserField(uid, 'email', payload.email);
+	}
+
+	await user.email.confirmByUid(uid);
+	winston.verbose(`[plugin/sso-oauth2-multiple] Confirmed email for uid ${uid} via ${payload.name}`);
+};
+
 OAuth.login = async (payload) => {
 	let uid = await OAuth.getUidByOAuthid(payload.name, payload.oAuthid);
 	if (uid !== null) {
 		// Existing User
+		await OAuth.confirmEmailIfTrusted(payload, uid);
 		return ({ uid });
 	}
 
-	const { trustEmailVerified } = await OAuth.getStrategy(payload.name);
+	const strategy = await OAuth.getStrategy(payload.name);
 	const { email } = payload;
-	const email_verified =
-		parseInt(trustEmailVerified, 10) &&
-		(payload.email_verified || payload.email_verified === true);
+	const email_verified = OAuth.isEmailTrusted(strategy, payload);
 
 
 	// Check for user via email fallback

--- a/library.js
+++ b/library.js
@@ -211,13 +211,17 @@ OAuth.getAssociations = async () => {
 	}));
 };
 
+OAuth.isEmailVerifiedByProvider = (strategy, payload) => (
+	!!parseInt(strategy.trustEmailVerified, 10) &&
+	(payload.email_verified || payload.email_verified === true)
+);
+
 OAuth.isEmailTrusted = (strategy, payload) => {
 	if (parseInt(strategy.skipEmailVerification, 10)) {
 		return true;
 	}
 
-	return !!parseInt(strategy.trustEmailVerified, 10) &&
-		(payload.email_verified || payload.email_verified === true);
+	return OAuth.isEmailVerifiedByProvider(strategy, payload);
 };
 
 OAuth.confirmEmailIfTrusted = async (payload, uid) => {
@@ -253,7 +257,7 @@ OAuth.login = async (payload) => {
 
 
 	// Check for user via email fallback
-	if (email && email_verified) {
+	if (email && OAuth.isEmailVerifiedByProvider(strategy, payload)) {
 		uid = await user.getUidByEmail(payload.email);
 	}
 

--- a/static/templates/partials/edit-oauth2-strategy.tpl
+++ b/static/templates/partials/edit-oauth2-strategy.tpl
@@ -121,6 +121,11 @@
 							<label for="trustEmailVerified" class="form-check-label">Automatically confirm emails when <code>email_verified</code> is true.</code></label>
 						</div>
 
+						<div class="form-check form-switch mb-3">
+							<input type="checkbox" class="form-check-input" id="skipEmailVerification" name="skipEmailVerification" {{{ if (./skipEmailVerification == "1") }}}checked{{{ end }}}>
+							<label for="skipEmailVerification" class="form-check-label">Skip email verification for people who register using SSO?</label>
+						</div>
+
 						<div class="mb-3">
 							<label class="form-label" for="idKey">Alternative <code>id</code> key</label>
 							<input type="text" id="idKey" name="idKey" title="Alternative id key" class="form-control" placeholder="e.g. auth0Id" value="{./idKey}">


### PR DESCRIPTION
Adds a per-strategy **"Skip email verification for people who register using SSO?"** option, mirroring the setting the first-party SSO plugins expose.

### Why

`trustEmailVerified` only confirms an email when the provider sends an `email_verified` claim that is truthy:

```js
const email_verified =
	parseInt(trustEmailVerified, 10) &&
	(payload.email_verified || payload.email_verified === true);
```

Not every provider sends that claim. Microsoft's `https://graph.microsoft.com/oidc/userinfo` is one — a real response contains `sub`, `givenname`, `familyname`, `email`, `locale` and `picture`, and no `email_verified` at all. The address is there and is the one the account is registered with, but `trustEmailVerified` can never fire, so every user arriving through that strategy stays unverified and hits the "posting in some categories is enabled once your email is confirmed" wall.

There is currently no way to express "I trust this provider's addresses outright". Loosening `trustEmailVerified` to treat a missing claim as verified would silently change behaviour for existing installs, so this adds an explicit opt-in instead and leaves `trustEmailVerified` exactly as it was.

### What changed

- New `skipEmailVerification` checkbox on the strategy editor, registered in `editStrategy`'s checkbox list so it is normalised to `1`/`0` like its siblings.
- The trust decision moves into `OAuth.isEmailTrusted(strategy, payload)`: the new option short-circuits to `true`, otherwise the existing `trustEmailVerified` behaviour is unchanged.
- `OAuth.login` returns early for users who already have an association, which meant the email was only ever confirmed at registration time. Turning the option on therefore did nothing for accounts that had already signed in once. `confirmEmailIfTrusted` closes that gap, and refuses to act when the account is already confirmed or when the stored address differs from the one the provider just sent.

### The email fallback is deliberately left alone

`OAuth.login` matches an incoming address against existing users before creating an account:

```js
if (email && email_verified) {
	uid = await user.getUidByEmail(payload.email);
}
```

Routing the new option through that same flag would mean "skip email verification" also silently grants "attach this provider to whatever account already owns the address it claims" — an account takeover vector for any provider that does not actually verify its addresses, up to and including an admin's account. So the two decisions are separated: `isEmailTrusted` (which the new option relaxes) governs confirmation, while `isEmailVerifiedByProvider` still demands a genuine `email_verified` claim before any account is matched by email.

### Testing

Verified on a live NodeBB 4.14.10 forum against a Microsoft strategy. With the option enabled, an account that had signed in previously moved to `email:confirmed = 1` and joined `verified-users` on its next login; with the option off, behaviour is identical to before. `npx eslint .` is clean.
