### PR TITLE
feat: optionally download the profile picture with the access token

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -74,7 +74,7 @@ Controllers.editStrategy = async (req, res) => {
 
 	payload.enabled = !!req.body.enabled;
 
-	const checkboxes = ['forceUsernameViaEmail', 'usernameViaEmail', 'trustEmailVerified', 'syncFullname', 'syncPicture'];
+	const checkboxes = ['forceUsernameViaEmail', 'usernameViaEmail', 'trustEmailVerified', 'syncFullname', 'syncPicture', 'fetchPictureWithToken'];
 	checkboxes.forEach((prop) => {
 		payload[prop] = payload.hasOwnProperty(prop) && payload[prop] === 'on' ? 1 : 0;
 	});

--- a/library.js
+++ b/library.js
@@ -154,6 +154,7 @@ OAuth.getUserProfile = function (name, userRoute, accessToken, done) {
 			const json = JSON.parse(body);
 			const profile = await OAuth.parseUserReturn(name, json);
 			profile.provider = name;
+			profile.accessToken = accessToken;
 			done(null, profile);
 		} catch (e) {
 			done(e);
@@ -277,10 +278,53 @@ OAuth.assignGroups = async ({ user, profile }) => {
 	winston.verbose(`[plugins/sso-auth0] uid ${uid} now a part of ${toJoin.length} these user groups: ${toJoin.join(', ')}`);
 };
 
+OAuth.syncPictureViaToken = async (uid, profile, strategy) => {
+	const enabled = parseInt(strategy.syncPicture, 10) && parseInt(strategy.fetchPictureWithToken, 10);
+	if (!enabled || !profile.picture || !profile.accessToken) {
+		return false;
+	}
+
+	const { uploadedpicture } = await user.getUserFields(uid, ['uploadedpicture']);
+	if (uploadedpicture) {
+		return true;
+	}
+
+	try {
+		const res = await fetch(profile.picture, {
+			headers: { Authorization: `Bearer ${profile.accessToken}` },
+		});
+		if (!res.ok) {
+			winston.verbose(`[plugin/sso-oauth2-multiple] Picture for uid ${uid} unavailable (${res.status})`);
+			return false;
+		}
+
+		const buffer = Buffer.from(await res.arrayBuffer());
+		if (!buffer.length) {
+			return false;
+		}
+
+		const type = (res.headers.get('content-type') || 'image/jpeg').split(';')[0];
+		await user.uploadCroppedPicture({
+			callerUid: uid,
+			uid,
+			imageData: `data:${type};base64,${buffer.toString('base64')}`,
+		});
+
+		return true;
+	} catch (err) {
+		winston.warn(`[plugin/sso-oauth2-multiple] Unable to sync picture for uid ${uid}: ${err.message}`);
+		return false;
+	}
+};
+
 OAuth.updateProfile = async (uid, profile) => {
 	const fields = ['fullname', 'picture'];
 	const strategy = await OAuth.getStrategy(profile.provider);
 	const allowList = [];
+
+	if (await OAuth.syncPictureViaToken(uid, profile, strategy)) {
+		fields.splice(fields.indexOf('picture'), 1);
+	}
 
 	const payload = fields.reduce((memo, field) => {
 		const setting = `sync${field[0].toUpperCase()}${field.slice(1)}`;

--- a/static/templates/partials/edit-oauth2-strategy.tpl
+++ b/static/templates/partials/edit-oauth2-strategy.tpl
@@ -142,6 +142,18 @@
 							<input type="checkbox" class="form-check-input" id="syncPicture" name="syncPicture" {{{ if (./syncPicture == "1") }}}checked{{{ end }}}>
 							<label for="syncPicture" class="form-check-label">Picture</label>
 						</div>
+
+						<div class="form-check form-switch mb-3">
+							<input type="checkbox" class="form-check-input" id="fetchPictureWithToken" name="fetchPictureWithToken" {{{ if (./fetchPictureWithToken == "1") }}}checked{{{ end }}}>
+							<label for="fetchPictureWithToken" class="form-check-label">
+								Download the picture using the access token instead of storing its URL
+								<p class="form-text">
+									Required when the picture URL is not publicly reachable, e.g. Microsoft Graph's
+									<code>/me/photo/$value</code>. The image is uploaded to this forum once, and is not
+									overwritten if the user later sets their own avatar.
+								</p>
+							</label>
+						</div>
 					</div>
 				</div>
 			</details>


### PR DESCRIPTION
Adds an opt-in **"Download the picture using the access token instead of storing its URL"** option next to the existing "Picture" sync toggle.

### Why

`updateProfile` stores the `picture` claim verbatim as the user's avatar URL. That works when the provider returns a publicly reachable image, but some return an API endpoint that is only readable with the access token. Microsoft's OIDC userinfo endpoint returns:

```json
"picture": "https://graph.microsoft.com/v1.0/me/photo/$value"
```

NodeBB stores that string, the browser then requests it anonymously, Microsoft answers `401`, and the user is left with a broken avatar that silently falls back to the letter icon. Nothing in the logs indicates a problem, because from the plugin's point of view the sync succeeded.

### What changed

- `getUserProfile` now carries the access token on the profile object. It was already available as an argument and simply discarded.
- `syncPictureViaToken` fetches the picture with an `Authorization: Bearer` header and hands the bytes to `user.uploadCroppedPicture`, so the avatar ends up hosted by the forum instead of pointing at a URL that only worked during the login request.
- When the download succeeds, `picture` is dropped from the fields passed to `user.updateProfile`, otherwise the raw URL would immediately overwrite the freshly uploaded avatar.

The option is off by default and gated behind the existing `syncPicture` toggle, so no existing strategy changes behaviour.

Two deliberate limits:

- The download runs only while the user has no uploaded avatar. This keeps it from re-uploading a new copy on every single login (which would grow the uploads directory indefinitely) and from overwriting an avatar the user has chosen themselves.
- Failures are non-fatal: a non-OK response is logged at `verbose`, an exception at `warn`, and the login proceeds. A missing profile picture should never block authentication.

### Testing

Verified on a live NodeBB 4.14.10 forum against a Microsoft strategy with `User.Read` in scope — note that the OIDC scopes alone are not enough to read `/me/photo/$value`. Before: `picture` was stored as the Graph URL and the avatar did not render. After: the image is fetched and stored under `/assets/uploads/profile/uid-<uid>/…`, and both `picture` and `uploadedpicture` point at it. Subsequent logins leave it untouched. `npx eslint .` is clean.
